### PR TITLE
Extended mysql test

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -10,6 +10,11 @@ parameters:
     # You should uncomment this if you want use pdo_sqlite
     # database_path: "%kernel.root_dir%/data.db3"
 
+    debbie_mysql_host: ~
+    debbie_mysql_dsn:  ~
+    debbie_mysql_user: ~
+    debbie_mysql_pass: ~
+
     mailer_transport:  smtp
     mailer_host:       127.0.0.1
     mailer_user:       ~

--- a/src/ConnectHolland/HealthCheckBundle/Health/Assertion/PDOAssertion.php
+++ b/src/ConnectHolland/HealthCheckBundle/Health/Assertion/PDOAssertion.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace ConnectHolland\HealthCheckBundle\Health\Assertion;
+
+use PDO;
+use PDOException;
+
+/**
+ * Assertion to attempt connecting a PDO instance
+ *
+ * @author Ron Rademaker
+ */
+class PDOAssertion extends AbstractAssertion
+{
+    /**
+     * The dsn to attempt to connect to
+     *
+     * @var string
+     */
+    private $dsn;
+
+    /**
+     * Optional username for connection
+     *
+     * @var string
+     */
+    private $username;
+
+    /**
+     * Optional password for connection
+     *
+     * @var string
+     */
+    private $password;
+
+    /**
+     * Optional connection options
+     *
+     * @var array
+     */
+    private $options = [];
+
+    /**
+     * Create a new PDOAssertion
+     *
+     * @param string $dsn
+     * @param string $username
+     * @param string $password
+     * @param array $options
+     */
+    public function __construct($dsn, $username = null, $password = null, array $options = array())
+    {
+        $this->dsn = $dsn;
+        $this->username = $username;
+        $this->password = $password;
+        $this->options = $options;
+    }
+
+    /**
+     * Assert a connection can be made
+     */
+    public function assert()
+    {
+        try {
+            new PDO($this->dsn, $this->username, $this->password, $this->options);
+            $this->succeed();
+        } catch (PDOException $ex) {
+            $this->fail();
+        }
+    }
+}

--- a/src/ConnectHolland/HealthCheckBundle/Health/Test/MySQL.php
+++ b/src/ConnectHolland/HealthCheckBundle/Health/Test/MySQL.php
@@ -2,6 +2,8 @@
 
 namespace ConnectHolland\HealthCheckBundle\Health\Test;
 
+use ConnectHolland\HealthCheckBundle\Health\Assertion\PDOAssertion;
+
 /**
  * Test availability of the MySQL service
  *
@@ -9,6 +11,63 @@ namespace ConnectHolland\HealthCheckBundle\Health\Test;
  */
 class MySQL extends AvailableService {
     /**
+     * Optional dsn to attempt to connect to
+     *
+     * @var string
+     */
+    private $dsn;
+
+    /**
+     * Optional username for connection
+     *
+     * @var string
+     */
+    private $username;
+
+    /**
+     * Optional password for connection
+     *
+     * @var string
+     */
+    private $password;
+
+    /**
+     * Optional connection options
+     *
+     * @var array
+     */
+    private $options = [];
+
+    /**
+     * Construct a new MySQL service test
+     *
+     * @param string $ip
+     * @param string $dsn
+     * @param string $username
+     * @param string $password
+     * @param array $options
+     */
+    public function __construct($ip, $dsn = null, $username = null, $password = null, array $options = array())
+    {
+        parent::__construct($ip);
+        $this->dsn = $dsn;
+        $this->username = $username;
+        $this->password = $password;
+        $this->options = $options;
+    }
+
+    /**
+     * Runs all assertions
+     */
+    public function run()
+    {
+        parent::run();
+        if (isset($this->dsn)) {
+            $this->assert(new PDOAssertion($this->dsn, $this->username, $this->password, $this->options));
+        }
+    }
+
+     /**
      * Returns the default mysql port
      */
     protected function getPort() {

--- a/src/ConnectHolland/HealthCheckBundle/Resources/config/services.xml
+++ b/src/ConnectHolland/HealthCheckBundle/Resources/config/services.xml
@@ -58,7 +58,10 @@
             <argument>localhost</argument>
         </service>
         <service id="connectholland_debbie.software_suite.mysql_sql01" class="ConnectHolland\HealthCheckBundle\Health\Test\MySQL">
-            <argument>sql01</argument>
+            <argument>%debbie_mysql_host%</argument>
+            <argument>%debbie_mysql_dsn%</argument>
+            <argument>%debbie_mysql_user%</argument>
+            <argument>%debbie_mysql_pass%</argument>
         </service>
    </services>
 </container>

--- a/src/ConnectHolland/HealthCheckBundle/Tests/Assertion/PDOAssertionTest.php
+++ b/src/ConnectHolland/HealthCheckBundle/Tests/Assertion/PDOAssertionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConnectHolland\HealthCheckBundle\Health\Assertion;
+
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Unit test to connect using PDO
+ *
+ * @author Ron Rademaker
+ */
+class PDOAssertionTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Try successful connection
+     */
+    public function testSuccess()
+    {
+        $assertion = new PDOAssertion('sqlite:unittest.sqlite');
+        $assertion->assert();
+
+        $this->assertTrue($assertion->isExecuted());
+        $this->assertFalse($assertion->isFailed());
+
+        unlink('unittest.sqlite');
+    }
+
+    /**
+     * Try failing connection
+     */
+    public function testFailure()
+    {
+        $assertion = new PDOAssertion('mysql:dbname=foobar;host=127.0.0.1', 'Debbie', 'Unittest'); // unlikely someone will use this
+        $assertion->assert();
+
+        $this->assertTrue($assertion->isExecuted());
+        $this->assertTrue($assertion->isFailed());
+    }
+}


### PR DESCRIPTION
Added actual PDO connection to mysql check to allow detecting issues like ```Unable to open PDO connection [wrapped: SQLSTATE[HY000] [1129] Host 'XXX.XXX.XXX.XXX is blocked because of many connection errors; unblock with 'mysqladmin flush-hosts']```